### PR TITLE
feat: propagate abort signal to image processing

### DIFF
--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -194,7 +194,7 @@ function removeApiKeyFromAuthFile(): void {
  * @throws Error if image cannot be downloaded or read
  * @internal
  */
-async function processImageUrl(imageUrl: string): Promise<string> {
+async function processImageUrl(imageUrl: string, signal?: AbortSignal): Promise<string> {
   // Remove @ prefix if present
   if (imageUrl.startsWith("@")) {
     imageUrl = imageUrl.slice(1);
@@ -207,7 +207,7 @@ async function processImageUrl(imageUrl: string): Promise<string> {
 
   // Handle HTTP/HTTPS URLs
   if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
-    const response = await fetch(imageUrl);
+    const response = await fetch(imageUrl, { signal });
     if (!response.ok) {
       throw new Error(`Failed to download image: ${response.statusText}`);
     }
@@ -658,7 +658,7 @@ Examples:
 
       try {
         // Process image to base64 data URL
-        const base64ImageUrl = await processImageUrl(params.image_url);
+        const base64ImageUrl = await processImageUrl(params.image_url, signal);
 
         onUpdate?.({
           content: [{ type: "text" as const, text: `🖼 Analyzing image...` }],


### PR DESCRIPTION
## Summary

Following up on [Gemini Code Assist's review](https://github.com/imsus/pi-extension-minimax-coding-plan-mcp/pull/8#pullrequestreview-4050815692), this PR propagates the `AbortSignal` to the `processImageUrl` function.

## Changes

- Added optional `signal` parameter to `processImageUrl(imageUrl, signal?)`
- Pass `signal` to `fetch()` call for image downloads
- Updated `understand_image` tool to pass `signal` to `processImageUrl`

## Why

When a user cancels a tool execution (e.g., via Ctrl+C), the abort signal should propagate to all async operations including image downloads. This ensures:

- ✅ Faster cancellation response
- ✅ Proper resource cleanup
- ✅ Better user experience

## Testing

```bash
npm run typecheck  # Passes ✓
```
